### PR TITLE
Ability to pass a client instead of using http.DefaultClient

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -15,16 +15,12 @@ type BotAPI struct {
 // NewBotAPI creates a new BotAPI instance.
 // Requires a token, provided by @BotFather on Telegram
 func NewBotAPI(token string) (*BotAPI, error) {
-	return NewBotAPIwithClient(token, nil)
+	return NewBotAPIwithClient(token, &http.Client{})
 }
 
-// NewBotAPI creates a new BotAPI instance passing an http.Client.
+// NewBotAPIWithClient creates a new BotAPI instance passing an http.Client.
 // Requires a token, provided by @BotFather on Telegram
-func NewBotAPIwithClient(token string, client *http.Client) (*BotAPI, error) {
-	if client == nil {
-		client = &http.Client{}
-	}
-
+func NewBotAPIWithClient(token string, client *http.Client) (*BotAPI, error) {
 	bot := &BotAPI{
 		Token:  token,
 		Client: client,

--- a/bot.go
+++ b/bot.go
@@ -1,19 +1,27 @@
 // Package tgbotapi has bindings for interacting with the Telegram Bot API.
 package tgbotapi
 
+import "net/http"
+
 // BotAPI has methods for interacting with all of Telegram's Bot API endpoints.
 type BotAPI struct {
 	Token   string      `json:"token"`
 	Debug   bool        `json:"debug"`
 	Self    User        `json:"-"`
 	Updates chan Update `json:"-"`
+	Client  http.Client `json:"-"`
 }
 
 // NewBotAPI creates a new BotAPI instance.
 // Requires a token, provided by @BotFather on Telegram
-func NewBotAPI(token string) (*BotAPI, error) {
+func NewBotAPI(token string, client http.Client) (*BotAPI, error) {
+	if client == nil {
+		client = &http.Client{}
+	}
+
 	bot := &BotAPI{
-		Token: token,
+		Token:  token,
+		Client: client,
 	}
 
 	self, err := bot.GetMe()

--- a/bot.go
+++ b/bot.go
@@ -14,14 +14,14 @@ type BotAPI struct {
 
 // NewBotAPI creates a new BotAPI instance.
 // Requires a token, provided by @BotFather on Telegram
-func NewBotAPI(token string, client http.Client) (*BotAPI, error) {
+func NewBotAPI(token string, client *http.Client) (*BotAPI, error) {
 	if client == nil {
 		client = &http.Client{}
 	}
 
 	bot := &BotAPI{
 		Token:  token,
-		Client: client,
+		Client: *client,
 	}
 
 	self, err := bot.GetMe()

--- a/bot.go
+++ b/bot.go
@@ -14,7 +14,13 @@ type BotAPI struct {
 
 // NewBotAPI creates a new BotAPI instance.
 // Requires a token, provided by @BotFather on Telegram
-func NewBotAPI(token string, client *http.Client) (*BotAPI, error) {
+func NewBotAPI(token string) (*BotAPI, error) {
+	return NewBotAPIwithClient(token, nil)
+}
+
+// NewBotAPI creates a new BotAPI instance passing an http.Client.
+// Requires a token, provided by @BotFather on Telegram
+func NewBotAPIwithClient(token string, client *http.Client) (*BotAPI, error) {
 	if client == nil {
 		client = &http.Client{}
 	}

--- a/bot.go
+++ b/bot.go
@@ -5,11 +5,11 @@ import "net/http"
 
 // BotAPI has methods for interacting with all of Telegram's Bot API endpoints.
 type BotAPI struct {
-	Token   string      `json:"token"`
-	Debug   bool        `json:"debug"`
-	Self    User        `json:"-"`
-	Updates chan Update `json:"-"`
-	Client  http.Client `json:"-"`
+	Token   string       `json:"token"`
+	Debug   bool         `json:"debug"`
+	Self    User         `json:"-"`
+	Updates chan Update  `json:"-"`
+	Client  *http.Client `json:"-"`
 }
 
 // NewBotAPI creates a new BotAPI instance.
@@ -21,7 +21,7 @@ func NewBotAPI(token string, client *http.Client) (*BotAPI, error) {
 
 	bot := &BotAPI{
 		Token:  token,
-		Client: *client,
+		Client: client,
 	}
 
 	self, err := bot.GetMe()

--- a/methods.go
+++ b/methods.go
@@ -190,7 +190,7 @@ func (bot *BotAPI) UploadFile(endpoint string, params map[string]string, fieldna
 
 	w.Close()
 
-	req, err := bot.Client.NewRequest("POST", "https://api.telegram.org/bot"+bot.Token+"/"+endpoint, &b)
+	req, err := http.NewRequest("POST", "https://api.telegram.org/bot"+bot.Token+"/"+endpoint, &b)
 	if err != nil {
 		return APIResponse{}, err
 	}

--- a/methods.go
+++ b/methods.go
@@ -131,7 +131,7 @@ type WebhookConfig struct {
 // MakeRequest makes a request to a specific endpoint with our token.
 // All requests are POSTs because Telegram doesn't care, and it's easier.
 func (bot *BotAPI) MakeRequest(endpoint string, params url.Values) (APIResponse, error) {
-	resp, err := http.PostForm("https://api.telegram.org/bot"+bot.Token+"/"+endpoint, params)
+	resp, err := bot.Client.PostForm("https://api.telegram.org/bot"+bot.Token+"/"+endpoint, params)
 	if err != nil {
 		return APIResponse{}, err
 	} else {
@@ -190,15 +190,14 @@ func (bot *BotAPI) UploadFile(endpoint string, params map[string]string, fieldna
 
 	w.Close()
 
-	req, err := http.NewRequest("POST", "https://api.telegram.org/bot"+bot.Token+"/"+endpoint, &b)
+	req, err := bot.Client.NewRequest("POST", "https://api.telegram.org/bot"+bot.Token+"/"+endpoint, &b)
 	if err != nil {
 		return APIResponse{}, err
 	}
 
 	req.Header.Set("Content-Type", w.FormDataContentType())
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := bot.Client.Do(req)
 	if err != nil {
 		return APIResponse{}, err
 	}


### PR DESCRIPTION
With ```tgbotapi.NewBotAPI(token, client)``` you can pass a client in case you can't use the default client like  in AppEngine. If you don't care you can pass ```nil``` as the client and the default client will be used. I've managed to make a bot with WebHooks in AppEngine passing the client like:
```go
c := appengine.NewContext(r)
client := urlfetch.Client(c)
bot, err := tgbotapi.NewBotAPI(token, &client)
```